### PR TITLE
Add Identity repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /coverage
 /.php-cs-fixer.cache
 /.phpunit.cache/
+/.build/

--- a/composer.json
+++ b/composer.json
@@ -53,8 +53,14 @@
         }
     },
     "scripts": {
-        "test": "vendor/bin/phpunit --testdox",
         "cs-fix": "vendor/bin/php-cs-fixer fix --diff --verbose",
-        "grumphp": "vendor/bin/grumphp run"
+        "grumphp": "vendor/bin/grumphp run",
+        "infection": "vendor/bin/infection --show-mutations",
+        "phpstan": "vendor/bin/phpstan",
+        "test": "vendor/bin/phpunit --testdox",
+        "test-coverage": [
+            "Composer\\Config::disableProcessTimeout",
+            "XDEBUG_MODE=coverage vendor/bin/phpunit --testdox --coverage-html=.build/coverage"
+        ]
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,5 +2,5 @@ parameters:
 	level: 9
 	paths:
 		- src
-	excludes_analyse:
-	    - tests/*
+		- tests
+	checkGenericClassInNonGenericObjectType: false

--- a/src/AbstractIdentity.php
+++ b/src/AbstractIdentity.php
@@ -23,17 +23,11 @@ use JeckelLab\Contract\Domain\Identity\Identity;
 abstract class AbstractIdentity implements Identity
 {
     /**
-     * @var array<class-string<Identity<int|string>>, array<string|int, Identity<int|string>>>
-     */
-    private static array $instances = [];
-
-    /**
      * @var IdentityType
      */
     private string|int $identity;
 
     /**
-     * @param int|string $id
      * @psalm-param IdentityType $id
      */
     final private function __construct(int|string $id)
@@ -44,20 +38,16 @@ abstract class AbstractIdentity implements Identity
         $this->identity = $id;
     }
 
-    /**
-     * @param int|string $identity
-     * @return static
-     */
     public static function from(int|string $identity): static
     {
-        if (isset(self::$instances[static::class][$identity])) {
-            /** @var static $instance */
-            $instance = self::$instances[static::class][$identity];
-            return $instance;
+        if (IdRepository::has(static::class, $identity)) {
+            /** @var static $identityInstance */
+            $identityInstance = IdRepository::get(static::class, $identity);
+            return $identityInstance;
         }
-
-        /** @psalm-suppress UnsafeGenericInstantiation */
-        return self::$instances[static::class][$identity] = new static($identity);
+        $identityInstance = new static($identity);
+        IdRepository::set($identityInstance);
+        return $identityInstance;
     }
 
     /**
@@ -65,9 +55,10 @@ abstract class AbstractIdentity implements Identity
      */
     public static function new(): static
     {
-        $identity = static::generateNewIdentity();
-        /** @psalm-suppress UnsafeGenericInstantiation */
-        return self::$instances[static::class][$identity] = new static($identity);
+        $id = static::generateNewIdentity();
+        $identity = new static($id);
+        IdRepository::set($identity);
+        return $identity;
     }
 
     /**

--- a/src/AbstractUuidIdentity.php
+++ b/src/AbstractUuidIdentity.php
@@ -35,6 +35,9 @@ abstract class AbstractUuidIdentity extends AbstractStringIdentity
      */
     public function isValid(int|string $id): bool
     {
-        return (preg_match('`^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$`D', (string) $id) === 1);
+        if (is_int($id)) {
+            return false;
+        }
+        return (preg_match('`^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$`D', $id) === 1);
     }
 }

--- a/src/IdRepository.php
+++ b/src/IdRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @author: Julien Mercier-Rojas <julien@jeckel-lab.fr>
+ * Created at: 16/10/2023
+ */
+
+declare(strict_types=1);
+
+namespace JeckelLab\IdentityContract;
+
+use JeckelLab\Contract\Domain\Identity\Identity;
+
+/**
+ * @SuppressWarnings(PHPMD.UnusedPrivateField)
+ */
+final class IdRepository
+{
+    /**
+     * @var array<class-string<Identity<int|string>>, array<int|string, Identity<int|string>>>
+     */
+    private array $identities = [];
+
+    private static function getInstance(): self
+    {
+        static $instance = null;
+        if ($instance === null) {
+            $instance = new self();
+        }
+        return $instance;
+    }
+
+    public static function has(string $identityFqcn, int|string $id): bool
+    {
+        return isset(self::getInstance()->identities[$identityFqcn][$id]);
+    }
+
+    public static function get(string $identityFqcn, int|string $id): ?Identity
+    {
+        return self::has($identityFqcn, $id) ? self::getInstance()->identities[$identityFqcn][$id] : null;
+    }
+
+    public static function set(Identity $identity): Identity
+    {
+        self::getInstance()->identities[get_class($identity)][$identity->id()] = $identity;
+        return $identity;
+    }
+}

--- a/tests/IdRepositoryTest.php
+++ b/tests/IdRepositoryTest.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @author: Julien Mercier-Rojas <julien@jeckel-lab.fr>
+ * Created at: 16/10/2023
+ */
+
+declare(strict_types=1);
+
+use JeckelLab\IdentityContract\IdRepository;
+use PHPUnit\Framework\TestCase;
+use Tests\JeckelLab\IdentityContract\Fixtures\FixtureIntIdentity;
+
+class IdRepositoryTest extends TestCase
+{
+    public function testAddingNewIdentityShouldMakeItAvailableLater(): void
+    {
+        $identity = FixtureIntIdentity::from(123);
+
+        self::assertTrue(IdRepository::has(FixtureIntIdentity::class, 123));
+        self::assertSame($identity, IdRepository::get(FixtureIntIdentity::class, 123));
+    }
+}

--- a/tests/IntIdentityTest.php
+++ b/tests/IntIdentityTest.php
@@ -8,6 +8,7 @@
 namespace Tests\JeckelLab\IdentityContract;
 
 use JeckelLab\IdentityContract\Exception\EnableToGenerateNewIdentityException;
+use JeckelLab\IdentityContract\IdRepository;
 use Tests\JeckelLab\IdentityContract\Fixtures\FixtureIntIdentity;
 use Tests\JeckelLab\IdentityContract\Fixtures\FixtureStringIdentity;
 use PHPUnit\Framework\TestCase;
@@ -23,16 +24,18 @@ class IntIdentityTest extends TestCase
 {
     public function testFromWithIntShouldSuccess(): void
     {
-        self::assertInstanceOf(FixtureIntIdentity::class, FixtureIntIdentity::from(25));
+        $identity = FixtureIntIdentity::from(25);
+        self::assertSame($identity, IdRepository::get(FixtureIntIdentity::class, 25));
     }
 
     /**
      * @dataProvider notIntData
      * @param mixed $invalidId
      */
-    public function testFromWithNotIntShouldFail($invalidId): void
+    public function testFromWithNotIntShouldFail(mixed $invalidId): void
     {
         $this->expectException(Throwable::class);
+        /** @phpstan-ignore-next-line */
         FixtureIntIdentity::from($invalidId);
     }
 
@@ -103,5 +106,4 @@ class IntIdentityTest extends TestCase
             [new stdClass()]
         ];
     }
-
 }

--- a/tests/StringIdentityTest.php
+++ b/tests/StringIdentityTest.php
@@ -7,6 +7,7 @@
 
 namespace Tests\JeckelLab\IdentityContract;
 
+use JeckelLab\IdentityContract\IdRepository;
 use Tests\JeckelLab\IdentityContract\Fixtures\FixtureIntIdentity;
 use Tests\JeckelLab\IdentityContract\Fixtures\FixtureStringCustomGeneratorIdentity;
 use Tests\JeckelLab\IdentityContract\Fixtures\FixtureStringIdentity;
@@ -18,31 +19,32 @@ class StringIdentityTest extends TestCase
 {
     public function testFromWithStringShouldSuccess(): void
     {
-        self::assertInstanceOf(FixtureStringIdentity::class, FixtureStringIdentity::from('barfoo'));
+        $identity = FixtureStringIdentity::from('barfoo');
+        self::assertEquals('barfoo', $identity->id());
+        self::assertEquals('barfoo', (string) $identity);
+        self::assertSame($identity, IdRepository::get(FixtureStringIdentity::class, 'barfoo'));
     }
 
     /**
      * @dataProvider notStringData
-     * @param $invalidId
+     * @param mixed $invalidId
      */
-    public function testFromWithNotStringShouldFail($invalidId): void
+    public function testFromWithNotStringShouldFail(mixed $invalidId): void
     {
         $this->expectException(Throwable::class);
+        /** @phpstan-ignore-next-line */
         FixtureStringIdentity::from($invalidId);
     }
 
     public function testNewShouldGenerateRandomId(): void
     {
         $id1 = FixtureStringIdentity::new();
-        self::assertInstanceOf(FixtureStringIdentity::class, $id1);
-
         $id2 = FixtureStringIdentity::new();
-        self::assertInstanceOf(FixtureStringIdentity::class, $id2);
-
         self::assertNotEquals($id1->id(), $id2->id());
 
         $customId = FixtureStringCustomGeneratorIdentity::new();
-        self::assertInstanceOf(FixtureStringCustomGeneratorIdentity::class, $customId);
+        self::assertNotEquals($id1->id(), $customId->id());
+        self::assertNotEquals(get_class($customId), get_class($id2));
     }
 
     public function testIdReturnTheProvidedId(): void

--- a/tests/UuidIdentityTest.php
+++ b/tests/UuidIdentityTest.php
@@ -9,11 +9,13 @@ declare(strict_types=1);
 
 namespace Tests\JeckelLab\IdentityContract;
 
+use JeckelLab\IdentityContract\IdRepository;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Tests\JeckelLab\IdentityContract\Fixtures\FixtureIntIdentity;
 use Tests\JeckelLab\IdentityContract\Fixtures\FixtureStringIdentity;
 use Tests\JeckelLab\IdentityContract\Fixtures\FixtureUuidIdentity;
+use Throwable;
 
 /**
  * Class UuidIdentityTest
@@ -24,39 +26,35 @@ class UuidIdentityTest extends TestCase
 {
     public function testFromWithValidUuidShouldSuccess(): void
     {
-        self::assertInstanceOf(
-            FixtureUuidIdentity::class,
-            FixtureUuidIdentity::from("f1a6e508-3bb4-4051-b854-746ac239d0e2")
+        $uuid = "f1a6e508-3bb4-4051-b854-746ac239d0e2";
+        $identity = FixtureUuidIdentity::from($uuid);
+        self::assertEquals(
+            $uuid,
+            $identity->id()
         );
-        self::assertInstanceOf(
-            FixtureUuidIdentity::class,
-            FixtureUuidIdentity::from("f1a6e508-3bb4-4051-b854-746ac239d0e2")
+        self::assertSame(
+            $identity,
+            FixtureUuidIdentity::from($uuid)
         );
     }
 
     /**
      * @dataProvider notValidUuidData
-     * @param $invalidId
+     * @param mixed $invalidId
      */
-    public function testFromWithNotUuidShouldFail($invalidId): void
+    public function testFromWithNotUuidShouldFail(mixed $invalidId): void
     {
-        try {
-            FixtureUuidIdentity::from($invalidId);
-        } catch (\Throwable $e) {
-            self::assertTrue(true);
-            return;
-        }
-        $this->fail('Should have thrown exception or error');
+        $this->expectException(Throwable::class);
+        /** @phpstan-ignore-next-line */
+        FixtureUuidIdentity::from($invalidId);
     }
 
     public function testNewWithoutArgumentsShouldGenerateRandomId(): void
     {
         $id1 = FixtureUuidIdentity::new();
-        self::assertInstanceOf(FixtureUuidIdentity::class, $id1);
+        self::assertSame($id1, IdRepository::get(FixtureUuidIdentity::class, $id1->id()));
 
         $id2 = FixtureUuidIdentity::new();
-        self::assertInstanceOf(FixtureUuidIdentity::class, $id2);
-
         self::assertNotEquals($id1->id(), $id2->id());
     }
 


### PR DESCRIPTION
Identity repository is used to retrieve the same instance each time you try to get an Identity with same value on same identity class